### PR TITLE
fix: serialization of KeyRefreshData<ProjectivePoint>

### DIFF
--- a/src/common/math.rs
+++ b/src/common/math.rs
@@ -1,4 +1,5 @@
 use crypto_bigint::subtle::ConstantTimeEq;
+use elliptic_curve::group::GroupEncoding;
 use elliptic_curve::Group;
 use ff::Field;
 use rand::{CryptoRng, RngCore};
@@ -24,7 +25,7 @@ pub fn get_lagrange_coeff<G: Group>(
     coeff
 }
 
-pub fn schnorr_split_private_key<G: Group, R: CryptoRng + RngCore>(
+pub fn schnorr_split_private_key<G: Group + GroupEncoding, R: CryptoRng + RngCore>(
     private_key: &G::Scalar,
     t: u8,
     n: u8,
@@ -59,7 +60,7 @@ pub fn schnorr_split_private_key<G: Group, R: CryptoRng + RngCore>(
 }
 
 /// Split the private keys into shares,
-pub fn schnorr_split_private_key_with_lost<G: Group, R: CryptoRng + RngCore>(
+pub fn schnorr_split_private_key_with_lost<G: Group + GroupEncoding, R: CryptoRng + RngCore>(
     private_key: &G::Scalar,
     t: u8,
     n: u8,

--- a/src/keygen/dkg.rs
+++ b/src/keygen/dkg.rs
@@ -32,7 +32,7 @@ pub const DKG_LABEL: &[u8] = b"SilenceLaboratories-Schnorr-DKG";
 /// The keygen party is a state machine that implements the keygen protocol.
 pub struct KeygenParty<T, G>
 where
-    G: Group,
+    G: Group + GroupEncoding,
 {
     params: KeygenParams,
     rand_params: KeyEntropy<G>,
@@ -98,7 +98,7 @@ fn validate_input(
 
 impl<G> KeygenParty<R0, G>
 where
-    G: Group,
+    G: Group + GroupEncoding,
 {
     /// Create a new keygen party.
     #[allow(clippy::too_many_arguments)]

--- a/src/keygen/refresh.rs
+++ b/src/keygen/refresh.rs
@@ -1,4 +1,4 @@
-use elliptic_curve::Group;
+use elliptic_curve::{group::GroupEncoding, Group};
 use ff::Field;
 
 use crate::common::traits::GroupElem;
@@ -9,7 +9,7 @@ use crate::common::utils::serde_point;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyRefreshData<G>
 where
-    G: Group,
+    G: Group + GroupEncoding,
 {
     /// Party id of the key share
     pub party_id: u8,

--- a/src/keygen/utils.rs
+++ b/src/keygen/utils.rs
@@ -1,3 +1,4 @@
+use elliptic_curve::group::GroupEncoding;
 use elliptic_curve::Group;
 use ff::Field;
 
@@ -12,7 +13,10 @@ use super::R0;
 
 use super::{messages::Keyshare, KeygenError, KeygenParty};
 
-pub fn setup_keygen<G: Group>(t: u8, n: u8) -> Result<Vec<KeygenParty<R0, G>>, KeygenError> {
+pub fn setup_keygen<G: Group + GroupEncoding>(
+    t: u8,
+    n: u8,
+) -> Result<Vec<KeygenParty<R0, G>>, KeygenError> {
     let mut rng = rand::thread_rng();
     // Initializing the keygen for each party.
     let (party_key_list, party_pubkey_list) = generate_pki(n.into(), &mut rng);


### PR DESCRIPTION
Add missing attribute to allow serialization of `KeyRefreshData<ProjectivePoint>`. 
Encountered this issue while adding Taproot support. This issue wasn't found before while adding ed25519 support as EdwardsPoint implements (De)Serialize traits. 