### PR TITLE
Remove unused parameter root_chain_code

### DIFF
--- a/src/keygen/dkg.rs
+++ b/src/keygen/dkg.rs
@@ -135,6 +135,7 @@ where
             extra_data,
         )
     }
+
     /// Create a new keygen protocol instance with a given context. Used for testing purposes internally.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_with_context(
@@ -183,6 +184,7 @@ where
             state: R0,
         })
     }
+
     pub fn encryption_key(&self) -> crypto_box::PublicKey {
         self.params.dec_key.public_key()
     }

--- a/src/keygen/refresh.rs
+++ b/src/keygen/refresh.rs
@@ -42,7 +42,6 @@ where
         party_id: u8,
         threshold: u8,
         total_parties: u8,
-        root_chain_code: [u8; 32],
     ) -> Self {
         KeyRefreshData {
             threshold,
@@ -51,9 +50,10 @@ where
             s_i_0: <G::Scalar as Field>::ZERO,
             lost_keyshare_party_ids,
             expected_public_key,
-            root_chain_code,
+            root_chain_code: [0; 32],
         }
     }
+
     pub fn make_refresh_data_migrate(
         party_id: u8,
         threshold: u8,
@@ -72,6 +72,7 @@ where
             root_chain_code,
         }
     }
+
     /// Get the private scalar (s_i) (not shamir secret)
     pub fn s_i(&self) -> &G::Scalar {
         &self.s_i_0

--- a/src/keygen/utils.rs
+++ b/src/keygen/utils.rs
@@ -95,6 +95,7 @@ where
     process_refresh::<T, N, G>(shares)?;
     Ok(())
 }
+
 //
 pub fn run_recovery<const T: usize, const N: usize, G: GroupElem>(
     keyshares: &[Keyshare<G>],
@@ -116,7 +117,6 @@ where
                 pid as u8,
                 T as u8,
                 N as u8,
-                keyshares[0].root_chain_code,
             )
         } else {
             keyshares[pid].get_refresh_data(Some(lost_party_ids.clone()))


### PR DESCRIPTION
Remove parameter root_chain_code from the method
KeyRefreshData::recovery_data_for_lost().

The root_chain_code is a secret component of the lost key share. It's impossible to pass a meaningful value, and it will be ignored by parties that have their own key shares.