### PR TITLE
Allow optional serialization of protocol state

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install stable toolchain
-      uses: dtolnay/rust-toolchain@1.78
+      uses: dtolnay/rust-toolchain@1.81
       with:
         components: clippy, rustfmt
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ serde = [
   "ed25519-dalek/serde",
   "k256/serde",
   "k256/pkcs8",
+  "sl-mpc-mate/serde",
+  "crypto_box/serde",
 ]
 
 [dependencies]
@@ -72,6 +74,7 @@ hmac = { version = "0.12.1" }
 [dev-dependencies]
 k256 = { version = "0.13.2" }
 bs58 = "0.5.0"
+ciborium = "0.2"
 tokio = { version = "1.34.0", features = [
   "rt",
   "sync",

--- a/src/common/math.rs
+++ b/src/common/math.rs
@@ -10,7 +10,10 @@ use rand::{CryptoRng, RngCore};
 
 use sl_mpc_mate::math::Polynomial;
 
-use crate::keygen::{KeyRefreshData, KeygenError};
+use crate::{
+    common::ser,
+    keygen::{KeyRefreshData, KeygenError},
+};
 
 pub fn get_lagrange_coeff<G: Group>(
     my_party_id: &u8,
@@ -36,7 +39,10 @@ pub fn schnorr_split_private_key<G: Group + GroupEncoding, R: CryptoRng + RngCor
     n: u8,
     root_chain_code: Option<[u8; 32]>,
     rng: &mut R,
-) -> Result<Vec<KeyRefreshData<G>>, KeygenError> {
+) -> Result<Vec<KeyRefreshData<G>>, KeygenError>
+where
+    G::Scalar: ser::Serializable,
+{
     if t < 2 || t > n {
         return Err(KeygenError::InvalidT);
     }
@@ -73,7 +79,10 @@ pub fn schnorr_split_private_key_with_lost<G: Group + GroupEncoding, R: CryptoRn
     lost_ids: Option<Vec<u8>>,
     root_chain_code: Option<[u8; 32]>,
     rng: &mut R,
-) -> Result<Vec<KeyRefreshData<G>>, KeygenError> {
+) -> Result<Vec<KeyRefreshData<G>>, KeygenError>
+where
+    G::Scalar: ser::Serializable,
+{
     if t < 2 || t > n {
         return Err(KeygenError::InvalidT);
     }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -114,3 +114,15 @@ pub mod traits {
         }
     }
 }
+
+#[cfg(not(feature = "serde"))]
+pub mod ser {
+    pub trait Serializable {}
+    impl<T> Serializable for T {}
+}
+
+#[cfg(feature = "serde")]
+pub mod ser {
+    pub trait Serializable: serde::Serialize + serde::de::DeserializeOwned {}
+    impl<T: serde::Serialize + serde::de::DeserializeOwned> Serializable for T {}
+}

--- a/src/derive/derivation.rs
+++ b/src/derive/derivation.rs
@@ -61,7 +61,7 @@ where
 mod test {
     use super::*;
 
-    use crate::common::utils::{run_keygen, run_round};
+    use crate::common::utils::{run_keygen, run_round_no_serde};
 
     #[allow(unused_imports)]
     use rand::prelude::SliceRandom;
@@ -78,7 +78,7 @@ mod test {
             .map(|keyshare| DeriveParty::new(keyshare.clone().into(), derivation_path))
             .collect::<Vec<_>>();
 
-        run_round(parties, ())
+        run_round_no_serde(parties, ())
     }
 
     #[cfg(feature = "eddsa")]

--- a/src/keygen/refresh.rs
+++ b/src/keygen/refresh.rs
@@ -7,9 +7,16 @@ use ff::Field;
 use crate::common::traits::GroupElem;
 
 #[cfg(feature = "serde")]
-use crate::common::utils::serde_point;
+use crate::common::{ser::Serializable, utils::serde_point};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "G: Group + GroupEncoding, G::Scalar: Serializable",
+        deserialize = "G: Group + GroupEncoding, G::Scalar: Serializable"
+    ))
+)]
 pub struct KeyRefreshData<G>
 where
     G: Group + GroupEncoding,

--- a/src/quorum_change/pairs.rs
+++ b/src/quorum_change/pairs.rs
@@ -5,6 +5,7 @@ use std::cmp::Ord;
 
 /// Small ordered set of pairs.
 #[derive(Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pairs<T, I = u8>(Vec<(I, T)>);
 
 impl<T: Clone> Clone for Pairs<T> {

--- a/src/quorum_change/types.rs
+++ b/src/quorum_change/types.rs
@@ -1,16 +1,21 @@
 // Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
 // This software is licensed under the Silence Laboratories License Agreement.
 
-use crate::group::Group;
-use crate::quorum_change::pairs::Pairs;
-use crate::quorum_change::qc::new_party_id;
 use crypto_bigint::rand_core::{CryptoRng, RngCore};
 use rand::Rng;
-use sl_mpc_mate::math::Polynomial;
-use sl_mpc_mate::random_bytes;
 use thiserror::Error;
 
+use crate::{
+    common::ser::Serializable,
+    group::Group,
+    quorum_change::{pairs::Pairs, qc::new_party_id},
+};
+
+use sl_mpc_mate::math::Polynomial;
+use sl_mpc_mate::random_bytes;
+
 /// Parameters for the QuorumChange protocol. Constant across all rounds.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct QCParams<G>
 where
     G: Group,
@@ -38,9 +43,11 @@ where
 }
 
 /// All random params needed for QuorumChange protocol.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QCEntropyOld<G>
 where
     G: Group,
+    G::Scalar: Serializable,
 {
     /// New threshold
     pub new_t: u8,
@@ -56,6 +63,7 @@ where
 impl<G> QCEntropyOld<G>
 where
     G: Group,
+    G::Scalar: Serializable,
 {
     /// Generate a new set of random params
     pub fn generate<R: CryptoRng + RngCore>(
@@ -86,6 +94,7 @@ where
 }
 
 /// All random params needed for QuorumChange protocol.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QCEntropyNew {
     /// sid_i for the QuorumChange protocol
     pub sid_i: [u8; 32],

--- a/src/sign/eddsa.rs
+++ b/src/sign/eddsa.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
+// This software is licensed under the Silence Laboratories License Agreement.
+
 use curve25519_dalek::{EdwardsPoint, Scalar};
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use elliptic_curve::group::GroupEncoding;
@@ -38,7 +41,6 @@ impl Round for SignReady<EdwardsPoint> {
 
         let next = PartialSign {
             party_id: self.party_id,
-            threshold: self.threshold,
             session_id: self.session_id,
             public_key: self.public_key,
             big_r: self.big_r,

--- a/src/sign/messages.rs
+++ b/src/sign/messages.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
+// This software is licensed under the Silence Laboratories License Agreement.
+
 use elliptic_curve::Group;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
+// This software is licensed under the Silence Laboratories License Agreement.
+
 use std::collections::HashSet;
 
 mod types;

--- a/src/sign/taproot.rs
+++ b/src/sign/taproot.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
+// This software is licensed under the Silence Laboratories License Agreement.
+
 use elliptic_curve::ops::Reduce;
 use k256::{schnorr::Signature, ProjectivePoint, Scalar, U256};
 use signature::hazmat::PrehashVerifier;
@@ -114,7 +117,6 @@ impl Round for SignReady<ProjectivePoint> {
         let next = PartialSign {
             public_key: self.public_key,
             party_id: self.party_id,
-            threshold: self.threshold,
             session_id: self.session_id,
             big_r: self.big_r,
             s_i,

--- a/src/sign/types.rs
+++ b/src/sign/types.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
+// This software is licensed under the Silence Laboratories License Agreement.
+
 #[cfg(any(feature = "taproot", feature = "eddsa"))]
 use elliptic_curve::Group;
 
@@ -10,11 +13,13 @@ use thiserror::Error;
 use crate::common::utils::SessionId;
 
 #[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// All random params needed for sign protocol
 pub struct SignEntropy<G: Group> {
     pub(crate) session_id: SessionId,
     pub(crate) k_i: G::Scalar,
     pub(crate) blind_factor: [u8; 32],
+    pub(crate) seed: [u8; 32],
 }
 
 #[cfg(any(feature = "taproot", feature = "eddsa"))]
@@ -24,6 +29,7 @@ impl<G: Group> SignEntropy<G> {
         Self {
             session_id: rng.gen(),
             blind_factor: rng.gen(),
+            seed: rng.gen(),
             k_i: <G::Scalar as ff::Field>::random(rng),
         }
     }


### PR DESCRIPTION
Make KeygenParty and SignParty serializable
- redefine SignParty by grouping all values calculated from passed key share and/or derivation path into a new Params structure.
- add appropriate derive attributes
- extend utility function `run_round()` to serialize/deserialize all "actors" to test the new feature.