### PR TITLE
Implement DKG Session

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install stable toolchain
-      uses: dtolnay/rust-toolchain@1.85
+      uses: dtolnay/rust-toolchain@1.88
       with:
         components: clippy, rustfmt
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ readme = "README.md"
 
 [[example]]
 name = "sign"
-required-features = [ "eddsa" ]
+required-features = [ "eddsa", "test-support" ]
 
 [[example]]
 name = "keygen"
-required-features = [ "eddsa" ]
+required-features = [ "eddsa", "test-support" ]
 
 [[example]]
 name = "refresh"
-required-features = [ "eddsa" ]
+required-features = [ "eddsa", "test-support" ]
 
 [features]
 default = ["eddsa"]
@@ -35,6 +35,7 @@ serde = [
   "sl-mpc-mate/serde",
   "crypto_box/serde",
 ]
+test-support = []
 
 [dependencies]
 zeroize = { version = "1.6.1", features = ["zeroize_derive"] }
@@ -61,7 +62,6 @@ curve25519-dalek = { version = "4.1.3", features = [
 k256 = { version = "0.13.2", default-features = false, optional = true }
 crypto-bigint = "0.5"
 rand = "0.8"
-rayon = "1.7.0"
 sha2 = "0.10.7"
 crypto_box = { version = "0.9.1" }
 ff = "0.13.0"

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Under [`examples/`](./examples/) directory there are examples on how to perform 
 
 Running the examples:
 ```bash
-cargo run --example keygen
-cargo run --example sign
-cargo run --example refresh
+cargo run --example keygen --features "eddsa test-support"
+cargo run --example sign --features "eddsa test-support"
+cargo run --example refresh --features "eddsa test-support"
 ```
 
 
@@ -63,10 +63,13 @@ cargo run --example refresh
 
 ### Feature Flags
 
-| Feature            | Default? | Description |
-| :---               |  :---:   | :---        |
-| `eddsa`            |    ✓     | Enables signing over curve25519 with edd25519-dalek signing objects compatibility|
-| `taproot`          |        | Enables Bitcoin Taproot Schnorr signing over secp256k1 |
+| Feature              | Default? | Description |
+| :---                 |  :---:   | :---        |
+| `eddsa`              |    ✓     | Enables signing over curve25519 with edd25519-dalek signing objects compatibility|
+| `taproot`            |          | Enables Bitcoin Taproot Schnorr signing over secp256k1 |
+| `serde`              |          | Make messages, state and session structures serializable |
+| `keyshare-session-id`|          | Enable field `final_session_id` in `Keyshare` structure and use it to calculate session-id for DSG |
+| `test-support`       |          | Enable internal helpers and fixtures required by the bundled examples |
 
 
 ## Security
@@ -76,7 +79,7 @@ If you discover a vulnerability, please follow the instructions in [SECURITY](SE
 ## Security Audit
 
 HashCloak has performed a security audit in April, 2025 on the following commit:
-- `146d4a57a82c62cf8d24fbd6b713d9bfc7cd534c` 
+- `146d4a57a82c62cf8d24fbd6b713d9bfc7cd534c`
 
 and the report is available here: [security audit](./docs/Hashcloak-SilenceLaboratories_2025_04_09.pdf)
 

--- a/examples/keygen.rs
+++ b/examples/keygen.rs
@@ -4,8 +4,9 @@
 use std::time::Instant;
 
 use curve25519_dalek::EdwardsPoint;
+
 use multi_party_schnorr::{
-    common::utils::run_round,
+    common::utils::support::run_round,
     group::GroupEncoding,
     keygen::{utils::setup_keygen, Keyshare},
 };
@@ -16,7 +17,7 @@ fn main() {
     let start = Instant::now();
 
     // Setup keygen, create the encryption keys for each party
-    let parties = setup_keygen(T as u8, N as u8).unwrap();
+    let parties = setup_keygen(T as u8, N as u8);
 
     // Locally run the keygen protocol
     // Run Round 1

--- a/examples/refresh.rs
+++ b/examples/refresh.rs
@@ -4,11 +4,10 @@
 use std::time::Instant;
 
 use curve25519_dalek::EdwardsPoint;
-
 use k256::elliptic_curve::group::GroupEncoding;
 
 use multi_party_schnorr::{
-    common::utils::{run_keygen, run_round},
+    common::utils::support::{run_keygen, run_round},
     keygen::utils::setup_refresh,
 };
 

--- a/examples/sign.rs
+++ b/examples/sign.rs
@@ -2,9 +2,12 @@
 // This software is licensed under the Silence Laboratories License Agreement.
 
 use curve25519_dalek::EdwardsPoint;
-use multi_party_schnorr::common::utils::{run_keygen, run_round};
-use multi_party_schnorr::sign::SignerParty;
 use rand::seq::SliceRandom;
+
+use multi_party_schnorr::{
+    common::utils::support::{run_keygen, run_round},
+    sign::SignerParty,
+};
 
 fn main() {
     const N: usize = 5;

--- a/src/common/math.rs
+++ b/src/common/math.rs
@@ -147,7 +147,7 @@ mod tests {
     use curve25519_dalek::EdwardsPoint;
     use rand::seq::SliceRandom;
 
-    use crate::common::utils::run_keygen;
+    use crate::common::utils::support::run_keygen;
 
     use super::combine_shares;
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -28,14 +28,33 @@ pub mod traits {
     #[cfg(feature = "taproot")]
     use elliptic_curve::ops::Reduce;
 
+    pub trait InitRound {
+        type OutputMessage;
+        type Next: Round;
+        type Error;
+
+        fn init(self) -> Result<(Self::Next, Self::OutputMessage), Self::Error>;
+    }
+
     /// Trait that defines a state transition for any round based protocol.
     pub trait Round {
         /// Output of the state transition.
         type Output;
-        /// Input of the state transition.
+
+        /// Type of input messages
+        type InputMessage;
+
+        /// Input of the state transition, such as `Vec<InputMessage>`.
         type Input;
+
+        type Error;
+
         /// Transition to the next state.
-        fn process(self, messages: Self::Input) -> Self::Output;
+        fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error>;
+    }
+
+    pub trait RoundSize {
+        fn message_count(&self) -> usize;
     }
 
     pub trait GroupElem: Group + GroupEncoding + ConstantTimeEq {}

--- a/src/keygen/messages.rs
+++ b/src/keygen/messages.rs
@@ -17,14 +17,11 @@ use sl_mpc_mate::bip32::BIP32Error;
 #[cfg(feature = "serde")]
 use crate::common::utils::{serde_point, serde_vec_point};
 
-use crate::{
-    common::{
-        get_lagrange_coeff,
-        traits::{BIP32Derive, GroupElem, ScalarReduce},
-        utils::{EncryptedData, HashBytes, SessionId},
-        DLogProof,
-    },
-    impl_basemessage,
+use crate::common::{
+    get_lagrange_coeff,
+    traits::{BIP32Derive, GroupElem, ScalarReduce},
+    utils::{EncryptedData, HashBytes, SessionId},
+    DLogProof,
 };
 
 use super::KeyRefreshData;
@@ -246,17 +243,17 @@ where
     }
 }
 
-impl_basemessage!(KeygenMsg1);
+impl crate::common::utils::BaseMessage for KeygenMsg1 {
+    fn party_id(&self) -> u8 {
+        self.from_party
+    }
+}
 
 impl<G> crate::common::utils::BaseMessage for KeygenMsg2<G>
 where
     G: GroupElem,
     G::Scalar: ScalarReduce<[u8; 32]>,
 {
-    fn session_id(&self) -> &SessionId {
-        &self.session_id
-    }
-
     fn party_id(&self) -> u8 {
         self.from_party
     }

--- a/src/keygen/mod.rs
+++ b/src/keygen/mod.rs
@@ -2,17 +2,15 @@
 // This software is licensed under the Silence Laboratories License Agreement.
 
 mod dkg;
-
-mod refresh;
-pub use refresh::*;
-
-mod types;
-
 mod messages;
+mod refresh;
+mod types;
 
 pub use dkg::*;
 pub use messages::*;
+pub use refresh::*;
 pub use types::*;
 
 /// Utility functions
+#[cfg(any(test, feature = "test-support"))]
 pub mod utils;

--- a/src/keygen/refresh.rs
+++ b/src/keygen/refresh.rs
@@ -98,7 +98,7 @@ where
 mod test {
     #[cfg(any(feature = "eddsa", feature = "taproot"))]
     use crate::{
-        common::utils::run_keygen,
+        common::utils::support::run_keygen,
         keygen::utils::{run_import, run_recovery, run_refresh},
     };
 

--- a/src/quorum_change/messages.rs
+++ b/src/quorum_change/messages.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
 // This software is licensed under the Silence Laboratories License Agreement.
 
-use crate::common::utils::{BaseP2PMessage, HashBytes, SessionId};
-use elliptic_curve::{group::GroupEncoding, Group};
 use std::hash::Hash;
-use std::mem;
+
+use elliptic_curve::{group::GroupEncoding, Group};
+
+use crate::common::utils::{HashBytes, SessionId};
 
 #[cfg(feature = "serde")]
 use crate::common::utils::serde_vec_point;
@@ -23,12 +24,6 @@ pub struct QCBroadcastMsg1 {
     pub commitment_1: HashBytes,
 }
 
-impl QCBroadcastMsg1 {
-    pub fn external_size() -> usize {
-        mem::size_of::<u8>() + mem::size_of::<SessionId>() + mem::size_of::<HashBytes>()
-    }
-}
-
 /// Type for the QC protocol's p2p message 1
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone)]
@@ -39,12 +34,6 @@ pub struct QCP2PMsg1 {
     pub to_party: u8,
     /// Participants commitment_2
     pub commitment_2: HashBytes,
-}
-
-impl QCP2PMsg1 {
-    pub fn external_size() -> usize {
-        mem::size_of::<HashBytes>() + 2
-    }
 }
 
 /// Type for the QC protocol's p2p message 2
@@ -66,15 +55,6 @@ where
     pub root_chain_code: [u8; 32],
 }
 
-impl<G> QCP2PMsg2<G>
-where
-    G: Group + GroupEncoding,
-{
-    pub fn external_size() -> usize {
-        mem::size_of::<G::Scalar>() + 32 + 32 + 2
-    }
-}
-
 /// Type for the QC protocol's broadcast message 2
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -91,43 +71,4 @@ where
     /// Participants Fik values
     #[cfg_attr(feature = "serde", serde(with = "serde_vec_point"))]
     pub big_p_i_poly: Vec<G>,
-}
-
-impl<G> QCBroadcastMsg2<G>
-where
-    G: Group + GroupEncoding,
-{
-    /// Returns size in bytes of QCBroadcastMsg2
-    /// from_party: 1 byte
-    /// r_1_i: 32 bytes
-    /// big_p_i_poly: l * point_size + 8,
-    /// where l is the vector length,
-    /// 8 - size in bytes for length
-    pub fn external_size(l: usize) -> usize {
-        let point_size = G::generator().to_bytes().as_ref().len();
-        1 + 32 + 8 + l * point_size
-    }
-}
-
-impl BaseP2PMessage for QCP2PMsg1 {
-    fn from_party(&self) -> usize {
-        self.from_party as usize
-    }
-
-    fn to_party(&self) -> usize {
-        self.to_party as usize
-    }
-}
-
-impl<G> BaseP2PMessage for QCP2PMsg2<G>
-where
-    G: Group + GroupEncoding,
-{
-    fn from_party(&self) -> usize {
-        self.from_party as usize
-    }
-
-    fn to_party(&self) -> usize {
-        self.to_party as usize
-    }
 }

--- a/src/quorum_change/qc.rs
+++ b/src/quorum_change/qc.rs
@@ -208,12 +208,13 @@ impl<G: GroupElem> Round for QCPartyOld<R0, G>
 where
     G::Scalar: Serializable,
 {
+    type InputMessage = ();
     type Input = ();
-
-    type Output = Result<(QCPartyOld<R1Old<G>, G>, QCBroadcastMsg1), QCError>;
+    type Error = QCError;
+    type Output = (QCPartyOld<R1Old<G>, G>, QCBroadcastMsg1);
 
     /// Creates first broadcast message
-    fn process(self, _: ()) -> Self::Output {
+    fn process(self, _: ()) -> Result<Self::Output, Self::Error> {
         let sid_i = self.rand_params.sid_i;
         let big_p_i_poly = self.rand_params.polynomial.commit();
         let r1_i = self.rand_params.r1_i;
@@ -244,20 +245,18 @@ where
     G: GroupElem,
     G::Scalar: Serializable,
 {
+    type InputMessage = QCBroadcastMsg1;
     type Input = Vec<QCBroadcastMsg1>;
-
-    type Output = Result<
-        (
-            QCPartyOld<R2Old<G>, G>,
-            Vec<QCP2PMsg1>,
-            Vec<QCP2PMsg2<G>>,
-            QCBroadcastMsg2<G>,
-        ),
-        QCError,
-    >;
+    type Error = QCError;
+    type Output = (
+        QCPartyOld<R2Old<G>, G>,
+        Vec<QCP2PMsg1>,
+        Vec<QCP2PMsg2<G>>,
+        QCBroadcastMsg2<G>,
+    );
 
     /// Processes BroadcastMsg1 and creates p2p commitment2, p2p decommit2, BroadcastMsg2
-    fn process(self, messages: Self::Input) -> Self::Output {
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
         let total_parties = self.params.total_parties as usize;
         if messages.len() != total_parties {
             return Err(QCError::InvalidMsgCount);
@@ -361,11 +360,12 @@ where
     G: GroupElem,
     G::Scalar: Serializable,
 {
+    type InputMessage = QCBroadcastMsg2<G>;
     type Input = Vec<QCBroadcastMsg2<G>>;
+    type Error = QCError;
+    type Output = ();
 
-    type Output = Result<(), QCError>;
-
-    fn process(self, messages: Self::Input) -> Self::Output {
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
         if messages.len() != self.params.old_parties.len() {
             return Err(QCError::InvalidMsgCount);
         }
@@ -493,12 +493,13 @@ where
     G: Group,
     G::Scalar: Serializable,
 {
+    type InputMessage = ();
     type Input = ();
-
-    type Output = Result<(QCPartyOldToNew<R1Old<G>, G>, QCBroadcastMsg1), QCError>;
+    type Error = QCError;
+    type Output = (QCPartyOldToNew<R1Old<G>, G>, QCBroadcastMsg1);
 
     /// Creates first broadcast message
-    fn process(self, _: ()) -> Self::Output {
+    fn process(self, _: ()) -> Result<Self::Output, Self::Error> {
         let sid_i = self.rand_params.sid_i;
         let big_p_i_poly = self.rand_params.polynomial.commit();
         let r1_i = self.rand_params.r1_i;
@@ -531,12 +532,13 @@ where
     G: GroupElem,
     G::Scalar: Serializable,
 {
+    type InputMessage = QCBroadcastMsg1;
     type Input = Vec<QCBroadcastMsg1>;
-
-    type Output = Result<(QCPartyOldToNew<R2OldToNew<G>, G>, Vec<QCP2PMsg1>), QCError>;
+    type Error = QCError;
+    type Output = (QCPartyOldToNew<R2OldToNew<G>, G>, Vec<QCP2PMsg1>);
 
     /// Processes BroadcastMsg1 and creates p2p commitment2
-    fn process(self, messages: Self::Input) -> Self::Output {
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
         let total_parties = self.params.total_parties as usize;
         if messages.len() != total_parties {
             return Err(QCError::InvalidMsgCount);
@@ -642,20 +644,18 @@ where
     G: GroupElem,
     G::Scalar: Serializable,
 {
+    type InputMessage = QCP2PMsg1;
     type Input = Vec<QCP2PMsg1>;
-
-    type Output = Result<
-        (
-            QCPartyOldToNew<R3OldToNew<G>, G>,
-            Vec<QCP2PMsg2<G>>,
-            QCBroadcastMsg2<G>,
-        ),
-        QCError,
-    >;
+    type Error = QCError;
+    type Output = (
+        QCPartyOldToNew<R3OldToNew<G>, G>,
+        Vec<QCP2PMsg2<G>>,
+        QCBroadcastMsg2<G>,
+    );
 
     /// Collects commitment_2 from (all old parties - 1)
     /// and creates p2p decommit2 and BroadcastMsg2
-    fn process(self, messages: Self::Input) -> Self::Output {
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
         if messages.len() != (self.params.old_parties.len() - 1) {
             return Err(QCError::InvalidMsgCount);
         }
@@ -731,12 +731,13 @@ where
     G: GroupElem,
     G::Scalar: Serializable,
 {
+    type InputMessage = ();
     type Input = (Vec<QCP2PMsg2<G>>, Vec<QCBroadcastMsg2<G>>);
-
-    type Output = Result<Keyshare<G>, QCError>;
+    type Error = QCError;
+    type Output = Keyshare<G>;
 
     /// Processes decomit_2 and BroadcastMsg2 from old parties
-    fn process(self, messages: Self::Input) -> Self::Output {
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
         let (mut p2p_messages, mut broadcast_msgs_2) = messages;
 
         if p2p_messages.len() != (self.params.old_parties.len() - 1) {
@@ -957,12 +958,13 @@ where
     G: Group,
     G::Scalar: Serializable,
 {
+    type InputMessage = ();
     type Input = ();
-
-    type Output = Result<(QCPartyNew<R1New, G>, QCBroadcastMsg1), QCError>;
+    type Error = QCError;
+    type Output = (QCPartyNew<R1New, G>, QCBroadcastMsg1);
 
     /// Creates first broadcast message
-    fn process(self, _: ()) -> Self::Output {
+    fn process(self, _: ()) -> Result<Self::Output, Self::Error> {
         let broadcast_msg1 = QCBroadcastMsg1 {
             from_party: self.params.party_index as u8,
             sid_i: self.rand_params.sid_i,
@@ -984,12 +986,13 @@ where
     G: GroupElem,
     G::Scalar: Serializable,
 {
+    type InputMessage = QCBroadcastMsg1;
     type Input = Vec<QCBroadcastMsg1>;
-
-    type Output = Result<QCPartyNew<R2New, G>, QCError>;
+    type Error = QCError;
+    type Output = QCPartyNew<R2New, G>;
 
     /// Processes BroadcastMsg1
-    fn process(self, messages: Self::Input) -> Self::Output {
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
         let total_parties = self.params.total_parties as usize;
         if messages.len() != total_parties {
             return Err(QCError::InvalidMsgCount);
@@ -1044,12 +1047,13 @@ where
     G: GroupElem,
     G::Scalar: Serializable,
 {
+    type InputMessage = QCP2PMsg1;
     type Input = Vec<QCP2PMsg1>;
-
-    type Output = Result<QCPartyNew<R3New, G>, QCError>;
+    type Error = QCError;
+    type Output = QCPartyNew<R3New, G>;
 
     /// Collects commitment_2 from all old parties
-    fn process(self, messages: Self::Input) -> Self::Output {
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
         if messages.len() != self.params.old_parties.len() {
             return Err(QCError::InvalidMsgCount);
         }
@@ -1093,12 +1097,13 @@ where
     G: GroupElem,
     G::Scalar: Serializable,
 {
+    type InputMessage = ();
     type Input = (Vec<QCP2PMsg2<G>>, Vec<QCBroadcastMsg2<G>>);
-
-    type Output = Result<Keyshare<G>, QCError>;
+    type Error = QCError;
+    type Output = Keyshare<G>;
 
     /// Processes decomit_2 and BroadcastMsg2 from old parties
-    fn process(self, messages: Self::Input) -> Self::Output {
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
         let (mut p2p_messages, mut broadcast_msgs_2) = messages;
 
         if p2p_messages.len() != self.params.old_parties.len() {
@@ -1320,7 +1325,7 @@ pub fn new_party_id(new_party_indices: &[usize], index: usize) -> Option<u8> {
 mod test {
     use super::*;
 
-    use crate::common::{traits::ScalarReduce, utils::run_keygen};
+    use crate::common::{traits::ScalarReduce, utils::support::run_keygen};
 
     use rand::Rng;
 

--- a/src/sign/messages.rs
+++ b/src/sign/messages.rs
@@ -25,7 +25,10 @@ pub struct SignMsg1 {
 /// Type for the sign gen message 2.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone)]
-pub struct SignMsg2<G: GroupElem> {
+pub struct SignMsg2<G>
+where
+    G: GroupElem,
+{
     /// Participant Id of the sender
     pub from_party: u8,
     /// Sesssion id
@@ -66,10 +69,6 @@ impl<G> BaseMessage for SignMsg2<G>
 where
     G: GroupElem,
 {
-    fn session_id(&self) -> &SessionId {
-        &self.session_id
-    }
-
     fn party_id(&self) -> u8 {
         self.from_party
     }
@@ -79,10 +78,6 @@ impl<G> BaseMessage for SignMsg3<G>
 where
     G: Group,
 {
-    fn session_id(&self) -> &SessionId {
-        &self.session_id
-    }
-
     fn party_id(&self) -> u8 {
         self.from_party
     }


### PR DESCRIPTION
Implement DKG Session and refactor protocol utilities

- Introduce a new `Session` abstraction to manage multi‑round DKG protocols, with support for initialization (`InitRound`), message collection, and state transitions.
- Add `InitRound` and `RoundSize` traits; extend the core `Round` trait to include associated `InputMessage`, `Error`, and `Result`‑based output.
- Split test‑only utilities (`run_keygen`, `run_round`, PKI generation) into a `support` module behind a new `test-support` Cargo feature.
- Update `Cargo.toml`:
  * Add `test-support` feature.
  * Adjust example required‑features to include `test-support`.
- Bump CI workflow:
  * Use `actions/checkout@v5`.
  * Update Rust toolchain to `1.88`.
- Refactor encryption API:
  * `encrypt_message` now takes a byte slice rather than a fixed array.
  * Remove unused generic `G` parameter and related scalar size checks.
- Remove the `impl_basemessage` macro and implement `BaseMessage` manually where needed.
- Adjust key generation (`dkg.rs`), refresh, and signing modules to use the new `Session` API and updated trait signatures.
- Update message types across the codebase (`keygen/messages.rs`, `sign/messages.rs`, `quorum_change/messages.rs`) to conform to the new `BaseMessage` definition and drop size helper methods.
- Modify quorum change protocol (`qc.rs`) to work with the new `Round` signatures and eliminate `BaseP2PMessage` implementations.
- Update examples (`keygen.rs`, `refresh.rs`, `sign.rs`) to import utilities from `common::utils::support`.
- Revise tests to use the new session handling and support utilities.
- General clean‑ups: streamline imports, tighten trait bounds, improve error handling, and remove dead code.