### PR TITLE
redpallas injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "multi-party-schnorr"
-version = "1.2.0"
+version = "1.2.0-pre.1"
 dependencies = [
  "blake2b_simd",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,12 +55,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -79,6 +113,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -129,6 +169,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpufeatures"
@@ -389,6 +435,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hmac"
@@ -406,6 +455,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "jubjub"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
+dependencies = [
+ "bitvec",
+ "bls12_381",
+ "ff",
+ "group",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -431,8 +494,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "multi-party-schnorr"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
+ "blake2b_simd",
  "bs58",
  "bytemuck",
  "ciborium",
@@ -443,10 +507,14 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "ff",
+ "group",
  "hmac",
  "k256",
+ "pasta_curves",
  "rand",
  "rand_chacha",
+ "rand_core",
+ "reddsa",
  "serde",
  "serde_bytes",
  "sha2",
@@ -468,6 +536,21 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "ff",
+ "group",
+ "hex",
+ "rand",
+ "serde",
+ "static_assertions",
+ "subtle",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -557,6 +640,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "reddsa"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "group",
+ "hex",
+ "jubjub",
+ "pasta_curves",
+ "rand_core",
+ "serde",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -709,6 +810,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-party-schnorr"
-version = "1.2.0"
+version = "1.2.0-pre.1"
 edition = "2021"
 license-file = "LICENSE"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,9 @@
 [package]
 name = "multi-party-schnorr"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license-file = "LICENSE"
-description = "Multi party schnorr protocol"
-repository = "https://github.com/silence-laboratories/multi-party-schnorr"
-keywords = ["mpc", "threshold_signatures", "schnorr"]
-readme = "README.md"
-rust-version = "1.88"
+
 
 [[example]]
 name = "sign"
@@ -25,6 +21,7 @@ required-features = [ "eddsa", "test-support" ]
 default = ["eddsa", "session"]
 eddsa = ["curve25519-dalek", "ed25519-dalek"]
 taproot = ["k256/schnorr"]
+redpallas = ["dep:pasta_curves", "dep:group", "dep:rand_core", "dep:blake2b_simd", "dep:reddsa"]
 keyshare-session-id = []
 serde = [
   "dep:serde",
@@ -35,6 +32,7 @@ serde = [
   "k256/pkcs8",
   "sl-mpc-mate/serde",
   "crypto_box/serde",
+  "pasta_curves?/serde",
 ]
 session = ["serde", "dep:ciborium"]
 test-support = []
@@ -71,6 +69,11 @@ thiserror = "1"
 derivation-path = "0.2.0"
 hmac = { version = "0.12.1" }
 ciborium = { version = "0.2", optional = true }
+group = { version = "0.13.0", optional = true }
+pasta_curves = { version = "0.5", default-features = false, optional = true }
+rand_core = { version = "0.6.4", optional = true }
+reddsa = { version = "0.5", optional = true }
+blake2b_simd = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 k256 = { version = "0.13.2" }

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ cargo run --example refresh --features "eddsa test-support"
 
 | Feature              | Default? | Description |
 | :---                 |  :---:   | :---        |
-| `eddsa`              |    ✓     | Enables signing over curve25519 with edd25519-dalek signing objects compatibility|
+| `eddsa`              |    ✓     | Enables signing over curve25519 with ed25519-dalek signing objects compatibility |
 | `taproot`            |          | Enables Bitcoin Taproot Schnorr signing over secp256k1 |
+| `redpallas`          |          | Enables RedDSA signing over Pallas (Zcash Orchard–compatible, verifiable with the `reddsa` crate) |
+| `session`            |    ✓     | Enables session support (serde + ciborium for encoding) |
 | `serde`              |          | Make messages, state and session structures serializable |
 | `keyshare-session-id`|          | Enable field `final_session_id` in `Keyshare` structure and use it to calculate session-id for DSG |
 | `test-support`       |          | Enable internal helpers and fixtures required by the bundled examples |

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,6 +7,9 @@ mod math;
 /// Utility functions
 pub mod utils;
 
+#[cfg(feature = "redpallas")]
+pub mod redpallas;
+
 pub use dlog_proof::*;
 
 pub use math::*;
@@ -102,6 +105,19 @@ pub mod traits {
         fn parse_offset(bytes: [u8; 32]) -> CtOption<k256::Scalar> {
             use ff::PrimeField;
             Self::from_repr(bytes.into())
+        }
+    }
+
+    #[cfg(feature = "redpallas")]
+    impl BIP32Derive for pasta_curves::Fq {
+        fn parse_offset(bytes: [u8; 32]) -> CtOption<pasta_curves::Fq> {
+            use ff::FromUniformBytes;
+            let mut wide = [0u8; 64];
+            wide[..32].copy_from_slice(&bytes);
+            CtOption::new(
+                <pasta_curves::Fq as FromUniformBytes<64>>::from_uniform_bytes(&wide),
+                1.into(),
+            )
         }
     }
 

--- a/src/common/redpallas.rs
+++ b/src/common/redpallas.rs
@@ -1,0 +1,196 @@
+// Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
+// This software is licensed under the Silence Laboratories License Agreement.
+
+use std::iter::Sum;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use blake2b_simd::Params as Blake2bParams;
+use crypto_bigint::subtle::ConstantTimeEq;
+use elliptic_curve::subtle;
+use ff::FromUniformBytes;
+use group::{Group, GroupEncoding};
+use pasta_curves::{pallas, Fq};
+use rand_core::RngCore;
+
+use crate::common::traits::ScalarReduce;
+
+/// Orchard SpendAuth basepoint for RedDSA (Pallas).
+/// Same as reddsa orchard::SpendAuth: pallas::Point::hash_to_curve("z.cash:Orchard")(b"G").
+const ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES: [u8; 32] = [
+    99, 201, 117, 184, 132, 114, 26, 141, 12, 161, 112, 123, 227, 12, 127, 12, 95, 68, 95, 62, 124,
+    24, 141, 59, 6, 214, 241, 40, 179, 35, 85, 183,
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RedPallasPoint(pub pallas::Point);
+
+impl RedPallasPoint {
+    /// Hash bytes to a scalar using BLAKE2b-512.
+    pub fn hash_randomizer(m: &[u8]) -> Fq {
+        const LABEL: &[u8] = b"SchnorrRedPallas";
+        let hash = Blake2bParams::new()
+            .hash_length(64)
+            .personal(LABEL)
+            .to_state()
+            .update(m)
+            .finalize();
+        <Fq as FromUniformBytes<64>>::from_uniform_bytes(hash.as_array())
+    }
+}
+
+impl Mul<&Fq> for RedPallasPoint {
+    type Output = RedPallasPoint;
+
+    fn mul(self, scalar: &Fq) -> Self::Output {
+        RedPallasPoint(self.0 * *scalar)
+    }
+}
+
+impl Mul<Fq> for RedPallasPoint {
+    type Output = RedPallasPoint;
+
+    fn mul(self, scalar: Fq) -> Self::Output {
+        RedPallasPoint(self.0 * scalar)
+    }
+}
+
+impl MulAssign<&Fq> for RedPallasPoint {
+    fn mul_assign(&mut self, scalar: &Fq) {
+        *self = *self * scalar;
+    }
+}
+
+impl MulAssign<Fq> for RedPallasPoint {
+    fn mul_assign(&mut self, scalar: Fq) {
+        *self = *self * scalar;
+    }
+}
+
+impl Add for RedPallasPoint {
+    type Output = RedPallasPoint;
+
+    fn add(self, rhs: RedPallasPoint) -> Self::Output {
+        RedPallasPoint(self.0 + rhs.0)
+    }
+}
+
+impl Add<&RedPallasPoint> for RedPallasPoint {
+    type Output = RedPallasPoint;
+
+    fn add(self, rhs: &RedPallasPoint) -> Self::Output {
+        RedPallasPoint(self.0 + rhs.0)
+    }
+}
+
+impl AddAssign for RedPallasPoint {
+    fn add_assign(&mut self, rhs: RedPallasPoint) {
+        self.0 += rhs.0;
+    }
+}
+
+impl AddAssign<&RedPallasPoint> for RedPallasPoint {
+    fn add_assign(&mut self, rhs: &RedPallasPoint) {
+        self.0 += rhs.0;
+    }
+}
+
+impl Sub for RedPallasPoint {
+    type Output = RedPallasPoint;
+
+    fn sub(self, rhs: RedPallasPoint) -> Self::Output {
+        RedPallasPoint(self.0 - rhs.0)
+    }
+}
+
+impl Sub<&RedPallasPoint> for RedPallasPoint {
+    type Output = RedPallasPoint;
+
+    fn sub(self, rhs: &RedPallasPoint) -> Self::Output {
+        RedPallasPoint(self.0 - rhs.0)
+    }
+}
+
+impl SubAssign for RedPallasPoint {
+    fn sub_assign(&mut self, rhs: RedPallasPoint) {
+        self.0 -= rhs.0;
+    }
+}
+
+impl SubAssign<&RedPallasPoint> for RedPallasPoint {
+    fn sub_assign(&mut self, rhs: &RedPallasPoint) {
+        self.0 -= rhs.0;
+    }
+}
+
+impl Neg for RedPallasPoint {
+    type Output = RedPallasPoint;
+
+    fn neg(self) -> Self::Output {
+        RedPallasPoint(-self.0)
+    }
+}
+
+impl Sum for RedPallasPoint {
+    fn sum<I: Iterator<Item = RedPallasPoint>>(iter: I) -> Self {
+        RedPallasPoint(iter.map(|p| p.0).sum())
+    }
+}
+
+impl<'a> Sum<&'a RedPallasPoint> for RedPallasPoint {
+    fn sum<I: Iterator<Item = &'a RedPallasPoint>>(iter: I) -> Self {
+        RedPallasPoint(iter.map(|p| p.0).sum())
+    }
+}
+
+impl Group for RedPallasPoint {
+    type Scalar = Fq;
+    fn generator() -> Self {
+        let mut repr = <pallas::Point as GroupEncoding>::Repr::default();
+        repr.as_mut()
+            .copy_from_slice(&ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES);
+        Self(pallas::Point::from_bytes(&repr).unwrap())
+    }
+    fn identity() -> Self {
+        Self(pallas::Point::identity())
+    }
+    fn is_identity(&self) -> crypto_bigint::subtle::Choice {
+        self.0.is_identity()
+    }
+    fn double(&self) -> Self {
+        Self(self.0.double())
+    }
+
+    fn random(mut rng: impl RngCore) -> Self {
+        let mut bytes = [0u8; 64];
+        rng.fill_bytes(&mut bytes);
+        let scalar = <Fq as FromUniformBytes<64>>::from_uniform_bytes(&bytes);
+        Self(Self::generator().0 * scalar)
+    }
+}
+
+impl GroupEncoding for RedPallasPoint {
+    type Repr = <pallas::Point as GroupEncoding>::Repr;
+    fn from_bytes(bytes: &Self::Repr) -> subtle::CtOption<Self> {
+        pallas::Point::from_bytes(bytes).map(Self)
+    }
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> subtle::CtOption<Self> {
+        pallas::Point::from_bytes_unchecked(bytes).map(Self)
+    }
+    fn to_bytes(&self) -> Self::Repr {
+        self.0.to_bytes()
+    }
+}
+
+impl ConstantTimeEq for RedPallasPoint {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+impl ScalarReduce<[u8; 32]> for Fq {
+    fn reduce_from_bytes(bytes: &[u8; 32]) -> Self {
+        let mut wide = [0u8; 64];
+        wide[..32].copy_from_slice(bytes);
+        <Fq as FromUniformBytes<64>>::from_uniform_bytes(&wide)
+    }
+}

--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -90,7 +90,7 @@ pub mod serde_vec_point {
     {
         let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
         let point_size = G::Repr::default().as_ref().len();
-        if bytes.len() % point_size != 0 {
+        if !bytes.len().is_multiple_of(point_size) {
             return Err(serde::de::Error::custom("Invalid number of bytes"));
         }
         let mut points = Vec::with_capacity(bytes.len() / point_size);

--- a/src/keygen/dkg.rs
+++ b/src/keygen/dkg.rs
@@ -832,6 +832,32 @@ mod test {
         run_keygen::<10, 10, EdwardsPoint>();
         run_keygen::<9, 20, EdwardsPoint>();
     }
+    #[cfg(feature = "redpallas")]
+    #[test]
+    fn keygen_redpallas() {
+        use crate::common::redpallas::RedPallasPoint;
+
+        run_keygen::<2, 2, RedPallasPoint>();
+        run_keygen::<2, 3, RedPallasPoint>();
+        run_keygen::<3, 5, RedPallasPoint>();
+        run_keygen::<5, 5, RedPallasPoint>();
+        run_keygen::<5, 10, RedPallasPoint>();
+        run_keygen::<10, 10, RedPallasPoint>();
+        run_keygen::<9, 20, RedPallasPoint>();
+    }
+    #[cfg(feature = "redpallas")]
+    #[test]
+    fn keygen_redpallas_session() {
+        use crate::common::redpallas::RedPallasPoint;
+
+        run_dkg_session::<2, 2, RedPallasPoint>();
+        run_dkg_session::<2, 3, RedPallasPoint>();
+        run_dkg_session::<3, 5, RedPallasPoint>();
+        run_dkg_session::<5, 5, RedPallasPoint>();
+        run_dkg_session::<5, 10, RedPallasPoint>();
+        run_dkg_session::<10, 10, RedPallasPoint>();
+        run_dkg_session::<9, 20, RedPallasPoint>();
+    }
 
     #[cfg(feature = "taproot")]
     #[test]

--- a/src/keygen/session.rs
+++ b/src/keygen/session.rs
@@ -497,4 +497,11 @@ mod tests {
 
         server_session::<ProjectivePoint>();
     }
+    #[cfg(feature = "redpallas")]
+    #[test]
+    fn session_redpallas() {
+        use crate::common::redpallas::RedPallasPoint;
+
+        server_session::<RedPallasPoint>();
+    }
 }

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -5,14 +5,14 @@ use std::collections::HashSet;
 
 mod types;
 
-#[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg(any(feature = "taproot", feature = "eddsa", feature = "redpallas"))]
 /// Messages used in the signing protocol
 pub mod messages;
 
-#[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg(any(feature = "taproot", feature = "eddsa", feature = "redpallas"))]
 mod shared_rounds;
 
-#[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg(any(feature = "taproot", feature = "eddsa", feature = "redpallas"))]
 pub use shared_rounds::*;
 
 #[cfg(feature = "taproot")]
@@ -22,6 +22,10 @@ pub mod taproot;
 #[cfg(feature = "eddsa")]
 /// EdDSA signing protocol using Curve25519
 pub mod eddsa;
+
+#[cfg(feature = "redpallas")]
+/// RedDSA signing protocol using RedPallas (compatible with Zcash reddsa)
+pub mod reddsa;
 
 pub use types::*;
 

--- a/src/sign/reddsa.rs
+++ b/src/sign/reddsa.rs
@@ -1,0 +1,199 @@
+// Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
+// This software is licensed under the Silence Laboratories License Agreement.
+
+//! RedDSA signing for RedPallas, compatible with Zcash reddsa verification.
+//! Challenge: BLAKE2b-512 with personalization "Zcash_RedPallasH", then R || vk || message, reduced to scalar.
+//! See: https://github.com/ZcashFoundation/reddsa
+
+use blake2b_simd::Params;
+use ff::{FromUniformBytes, PrimeField};
+use group::GroupEncoding;
+use pasta_curves::Fq;
+use reddsa::orchard::SpendAuth;
+use reddsa::{Signature, VerificationKey};
+
+use crate::common::redpallas::RedPallasPoint;
+use crate::common::traits::Round;
+
+use super::{
+    messages::{SignComplete, SignMsg3},
+    validate_input_messages, PartialSign, SignError, SignReady,
+};
+
+const REDPALLAS_H_STAR_PERSONALIZATION: [u8; 16] = *b"Zcash_RedPallasH";
+
+fn reddsa_challenge(r_bytes: &[u8], vk_bytes: &[u8], message: &[u8]) -> Fq {
+    let hash = Params::new()
+        .hash_length(64)
+        .personal(&REDPALLAS_H_STAR_PERSONALIZATION)
+        .to_state()
+        .update(r_bytes)
+        .update(vk_bytes)
+        .update(message)
+        .finalize();
+    <Fq as FromUniformBytes<64>>::from_uniform_bytes(hash.as_array())
+}
+
+fn reddsa_verify(
+    vk_bytes: &[u8; 32],
+    message: &[u8],
+    sig_bytes: &[u8; 64],
+) -> Result<(), SignError> {
+    let vk = VerificationKey::<SpendAuth>::try_from(*vk_bytes)
+        .map_err(|_| SignError::InvalidSignature)?;
+    let sig = Signature::<SpendAuth>::from(*sig_bytes);
+    vk.verify(message, &sig)
+        .map_err(|_| SignError::InvalidSignature)
+}
+
+impl Round for SignReady<RedPallasPoint> {
+    type InputMessage = ();
+    type Input = ();
+    type Error = SignError;
+    type Output = (PartialSign<RedPallasPoint>, SignMsg3<RedPallasPoint>);
+
+    fn process(self, _: Self::Input) -> Result<Self::Output, Self::Error> {
+        let r_bytes = self.big_r.to_bytes();
+        let vk_bytes = self.public_key.to_bytes();
+
+        let c = reddsa_challenge(r_bytes.as_ref(), vk_bytes.as_ref(), &self.message);
+
+        let s_i = self.k_i + self.d_i * c;
+
+        let msg3 = SignMsg3 {
+            from_party: self.party_id,
+            session_id: self.session_id,
+            s_i,
+        };
+
+        let next = PartialSign {
+            party_id: self.party_id,
+            session_id: self.session_id,
+            public_key: self.public_key,
+            big_r: self.big_r,
+            s_i,
+            msg_to_sign: self.message,
+            pid_list: self.pid_list,
+        };
+
+        Ok((next, msg3))
+    }
+}
+
+impl Round for PartialSign<RedPallasPoint> {
+    type InputMessage = SignMsg3<RedPallasPoint>;
+    type Input = Vec<SignMsg3<RedPallasPoint>>;
+    type Error = SignError;
+    type Output = ([u8; 64], SignComplete);
+
+    fn process(self, messages: Self::Input) -> Result<Self::Output, Self::Error> {
+        let messages = validate_input_messages(messages, &self.pid_list)?;
+        let mut s = self.s_i;
+        for msg in messages {
+            if msg.from_party == self.party_id {
+                continue;
+            }
+            s += msg.s_i;
+        }
+
+        let r_bytes = self.big_r.to_bytes();
+        let vk_bytes = self.public_key.to_bytes();
+
+        let mut s_bytes = [0u8; 32];
+        s_bytes.copy_from_slice(s.to_repr().as_ref());
+
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[..32].copy_from_slice(r_bytes.as_ref());
+        sig_bytes[32..].copy_from_slice(&s_bytes);
+
+        let vk_arr: [u8; 32] = vk_bytes
+            .as_ref()
+            .try_into()
+            .map_err(|_| SignError::InvalidSignature)?;
+
+        reddsa_verify(&vk_arr, &self.msg_to_sign, &sig_bytes)?;
+
+        let sign_complete = SignComplete {
+            from_party: self.party_id,
+            session_id: self.session_id,
+            signature: sig_bytes,
+        };
+
+        Ok((sig_bytes, sign_complete))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rand::seq::SliceRandom;
+
+    use super::*;
+    use crate::{
+        common::utils::support::{run_keygen, run_round},
+        keygen::Keyshare,
+        sign::SignerParty,
+    };
+
+    fn run_sign(shares: Vec<Keyshare<RedPallasPoint>>) -> [u8; 64] {
+        let msg = b"BitGo rules them all";
+
+        let mut rng = rand::thread_rng();
+
+        let parties = shares
+            .into_iter()
+            .map(Arc::new)
+            .map(|keyshare| {
+                SignerParty::<_, RedPallasPoint>::new(
+                    keyshare,
+                    msg.to_vec(),
+                    "m/0".parse().unwrap(),
+                    &mut rng,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let (parties, msgs): (Vec<_>, Vec<_>) = run_round(parties, ()).into_iter().unzip();
+        let (parties, msgs): (Vec<_>, Vec<_>) = run_round(parties, msgs).into_iter().unzip();
+        let ready_parties = run_round(parties, msgs);
+
+        let (parties, partial_sigs): (Vec<_>, Vec<_>) =
+            run_round(ready_parties, ()).into_iter().unzip();
+
+        let (signatures, _complete_msg): (Vec<_>, Vec<_>) =
+            run_round(parties, partial_sigs).into_iter().unzip();
+
+        signatures[0]
+    }
+
+    #[test]
+    fn sign_2_2() {
+        let shares = run_keygen::<2, 2, RedPallasPoint>();
+        let subset: Vec<_> = shares
+            .choose_multiple(&mut rand::thread_rng(), 2)
+            .cloned()
+            .collect();
+        run_sign(subset);
+    }
+
+    #[test]
+    fn sign_2_3() {
+        let shares = run_keygen::<2, 3, RedPallasPoint>();
+        let subset: Vec<_> = shares
+            .choose_multiple(&mut rand::thread_rng(), 2)
+            .cloned()
+            .collect();
+        run_sign(subset);
+    }
+
+    #[test]
+    fn sign_3_5() {
+        let shares = run_keygen::<3, 5, RedPallasPoint>();
+        let subset: Vec<_> = shares
+            .choose_multiple(&mut rand::thread_rng(), 3)
+            .cloned()
+            .collect();
+        run_sign(subset);
+    }
+}

--- a/src/sign/types.rs
+++ b/src/sign/types.rs
@@ -1,18 +1,18 @@
 // Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
 // This software is licensed under the Silence Laboratories License Agreement.
 
-#[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg(any(feature = "taproot", feature = "eddsa", feature = "redpallas"))]
 use elliptic_curve::Group;
 
-#[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg(any(feature = "taproot", feature = "eddsa", feature = "redpallas"))]
 use rand::{CryptoRng, Rng, RngCore};
 
 use thiserror::Error;
 
-#[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg(any(feature = "taproot", feature = "eddsa", feature = "redpallas"))]
 use crate::common::utils::SessionId;
 
-#[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg(any(feature = "taproot", feature = "eddsa", feature = "redpallas"))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// All random params needed for sign protocol
 pub struct SignEntropy<G: Group> {
@@ -22,7 +22,7 @@ pub struct SignEntropy<G: Group> {
     pub(crate) seed: [u8; 32],
 }
 
-#[cfg(any(feature = "taproot", feature = "eddsa"))]
+#[cfg(any(feature = "taproot", feature = "eddsa", feature = "redpallas"))]
 impl<G: Group> SignEntropy<G> {
     /// Generate all the random values used in the sign protocol
     pub fn generate<R: CryptoRng + RngCore>(rng: &mut R) -> Self {


### PR DESCRIPTION
- [x] keygen
- [x] sign
- [x] rerand: That is a new protocol only for redpallas feature enabled which affects R2 of signing. By default it tweaks each party secret share by common randomness  `a: s_i = s_i + a` and the corresponding` PK_new=PK_old+ G*a*threhold`. So the signature is verified by PK_new. The reason behind that is to support anonymity as the signature cannot be  traced back to a single user (quorum) original published PK.

The common randomness `a = Blake2b(\alpha)` is computed using the existing commitments for k_i nonce as follows:

- From sign.R1 each party already commits to individual nonce k_i with a commitment cmt_r_i
- All parties compute \alpha = Sum (cmt_r_i) in R2 of sign.
That provides simplicity without extra messages or rounds to compute common random tweak. 

Alternatively each party can chose individual randomness z_i , send a commitment and then open such as they all compute Sum z_i as the randomizer

Now commitments needs to be sent encrypted P2P