### PR TITLE
Expose alpha from DSG round 2

### DIFF
--- a/src/sign/reddsa.rs
+++ b/src/sign/reddsa.rs
@@ -142,7 +142,8 @@ mod tests {
     fn finish_sign_rounds(parties: Vec<SignerParty<R0, RedPallasPoint>>) -> [u8; 64] {
         let (parties, msgs): (Vec<_>, Vec<_>) = run_round(parties, ()).into_iter().unzip();
         let (parties, msgs): (Vec<_>, Vec<_>) = run_round(parties, msgs).into_iter().unzip();
-        let ready_parties = run_round(parties, msgs);
+        let (ready_parties, _alphas): (Vec<_>, Vec<_>) =
+            run_round(parties, msgs).into_iter().unzip();
         let (parties, partial_sigs): (Vec<_>, Vec<_>) =
             run_round(ready_parties, ()).into_iter().unzip();
         let (signatures, _): (Vec<_>, Vec<_>) =
@@ -212,6 +213,30 @@ mod tests {
         run_sign_via_new(subset.clone());
         run_sign::<Legacy>(subset.clone());
         assert_bip32_public_derivation_unsupported(&subset);
+    }
+
+    #[test]
+    fn alpha_consistent_across_parties() {
+        let shares = run_keygen::<2, 3, RedPallasPoint>();
+        let subset: Vec<_> = shares
+            .choose_multiple(&mut rand::thread_rng(), 2)
+            .cloned()
+            .collect();
+        let msg = b"test alpha consistency";
+        let path: derivation_path::DerivationPath = "m/0".parse().unwrap();
+        let mut rng = rand::thread_rng();
+        let parties: Vec<SignerParty<_, RedPallasPoint>> = subset
+            .into_iter()
+            .map(Arc::new)
+            .map(|ks| SignerParty::<_, RedPallasPoint>::new(ks, msg.to_vec(), path.clone(), &mut rng))
+            .collect();
+        let (parties, msgs): (Vec<_>, Vec<_>) = run_round(parties, ()).into_iter().unzip();
+        let (parties, msgs): (Vec<_>, Vec<_>) = run_round(parties, msgs).into_iter().unzip();
+        let (_, alphas): (Vec<_>, Vec<_>) = run_round(parties, msgs).into_iter().unzip();
+        // All parties must compute the same alpha.
+        assert_eq!(alphas[0], alphas[1]);
+        // Alpha must be non-zero (randomization is applied).
+        assert_ne!(alphas[0], pasta_curves::Fq::from(0u64));
     }
 
     #[test]

--- a/src/sign/shared_rounds.rs
+++ b/src/sign/shared_rounds.rs
@@ -608,7 +608,9 @@ impl Round for SignerParty<R2<RedPallasPoint>, RedPallasPoint> {
     type InputMessage = SignMsg2<RedPallasPoint>;
     type Input = Vec<SignMsg2<RedPallasPoint>>;
     type Error = SignError;
-    type Output = SignReady<RedPallasPoint>;
+    /// Returns `(ready_state, alpha)` where `alpha` is the per-session randomization
+    /// scalar needed for Orchard proof generation.
+    type Output = (SignReady<RedPallasPoint>, pasta_curves::Fq);
 
     fn process(self, msgs: Self::Input) -> Result<Self::Output, Self::Error> {
         let msgs = validate_input_messages(msgs, &self.state.pid_list)?;
@@ -692,20 +694,21 @@ impl Round for SignerParty<R2<RedPallasPoint>, RedPallasPoint> {
 
         let d_i = d_i + additive_offset + rand_offset_hashed;
 
+        let alpha = rand_offset_hashed * pasta_curves::Fq::from(participants as u64);
+
         let next = SignReady {
             big_r: big_r_i,
             d_i,
             pid_list: self.state.pid_list,
             public_key: self.params.derived_public_key
-                + (RedPallasPoint::generator()
-                    * (rand_offset_hashed * pasta_curves::Fq::from(participants as u64))),
+                + (RedPallasPoint::generator() * alpha),
             session_id: self.state.final_session_id,
             message: self.params.message,
             k_i: self.rand_params.k_i,
             party_id: self.params.party_id,
         };
 
-        Ok(next)
+        Ok((next, alpha))
     }
 }
 


### PR DESCRIPTION
Return the per-session randomization scalar (alpha) from the RedPallas SignerParty<R2> round as part of its output tuple. This scalar is needed by callers generating Orchard proofs, where alpha = rk - ak (the difference between the randomized and spending auth keys).