### PR TITLE
keygen: fix Taproot key ID calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "multi-party-schnorr"
-version = "1.3.0-pre.6"
+version = "1.3.0-pre.7"
 dependencies = [
  "blake2b_simd",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "multi-party-schnorr"
-version = "1.3.0-pre.6"
+version = "1.3.0-pre.7"
 edition = "2021"
 license-file = "LICENSE"
 description = "Multi party Schnorr protocol"

--- a/src/keygen/dkg.rs
+++ b/src/keygen/dkg.rs
@@ -592,30 +592,28 @@ where
             }
         }
 
+        #[cfg(feature = "taproot")]
+        let (public_key, d_i_share) = {
+            use core::ops::Neg;
+            use elliptic_curve::point::AffineCoordinates;
+
+            if (&public_key as &dyn core::any::Any)
+                .downcast_ref::<k256::ProjectivePoint>()
+                .is_some_and(|taproot_pubkey| bool::from(taproot_pubkey.to_affine().y_is_odd()))
+            {
+                // If the type is ProjectivePoint with an odd y-coordinate, then we are using
+                // Taproot and return the tweaked public key.
+                (public_key.neg(), d_i_share.neg())
+            } else {
+                // Otherwise, we return the compressed public key.
+                (public_key, d_i_share)
+            }
+        };
+
         let key_id = self
             .params
             .key_id
             .unwrap_or_else(|| sha2::Sha256::digest(public_key.to_bytes()).into());
-
-        #[cfg(feature = "taproot")]
-        let (public_key, d_i_share) = match std::any::type_name::<G>() {
-            // If the type is ProjectivePoint, then we are using Taproot
-            // We return the tweaked public key
-            "k256::arithmetic::projective::ProjectivePoint" => {
-                use elliptic_curve::point::AffineCoordinates;
-                use std::{any::Any, ops::Neg};
-                let taproot_pubkey = (&public_key as &dyn Any)
-                    .downcast_ref::<k256::ProjectivePoint>()
-                    .unwrap();
-                if taproot_pubkey.to_affine().y_is_odd().unwrap_u8() == 1 {
-                    (public_key.neg(), d_i_share.neg())
-                } else {
-                    (public_key, d_i_share)
-                }
-            }
-            // Otherwise, we return the compressed public key
-            _ => (public_key, d_i_share),
-        };
 
         let keyshare = Keyshare {
             threshold: self.params.t,


### PR DESCRIPTION
Detect Taproot points using `Any::downcast_ref` and calculate the default key ID after applying the Taproot public-key tweak.